### PR TITLE
Fix table sibling text extraction

### DIFF
--- a/src/markdown-downloader.ts
+++ b/src/markdown-downloader.ts
@@ -418,8 +418,8 @@ async function downloadMarkdownFromPage(
           const tables = Array.from(document.querySelectorAll('table'));
           return tables.map(table => ({
             html: table.innerHTML,
-            prevText: table.previousElementSibling?.innerText?.trim() || '',
-            nextText: table.nextElementSibling?.innerText?.trim() || ''
+            prevText: table.previousElementSibling?.textContent?.trim() || '',
+            nextText: table.nextElementSibling?.textContent?.trim() || ''
           }));
         });
 


### PR DESCRIPTION
## Summary
- fix DOM text extraction in markdown downloader

## Testing
- `npm run build`
- `npm test` *(fails: Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_b_684f2dab951c83339a6e0b117acca5e8