### PR TITLE
Fix Cheerio import for markdown table conversion

### DIFF
--- a/src/markdown-downloader.ts
+++ b/src/markdown-downloader.ts
@@ -1,10 +1,11 @@
 import fs from 'fs-extra';
 import path from 'path';
 import puppeteer from 'puppeteer';
-import cheerio from 'cheerio';
+// Use named import for compatibility with both ES modules and CommonJS
+import { load } from 'cheerio';
 
 function htmlTableToMarkdown(html: string): string {
-  const $ = cheerio.load(html);
+  const $ = load(html);
   const rows = $('tr');
   const table: string[][] = [];
   rows.each((i, row) => {


### PR DESCRIPTION
## Summary
- use named import from `cheerio` for compatibility when running under ESM

## Testing
- `npm test` *(fails: Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_b_684f30bd0dd48333a06006fccb4a1091